### PR TITLE
Self signed cert

### DIFF
--- a/1.10/Dockerfile
+++ b/1.10/Dockerfile
@@ -102,7 +102,7 @@ RUN addgroup -S -g 82 www-data && \
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY fastcgi_params /etc/nginx/fastcgi_params
 COPY drupal* /opt/
-ADD ssl.conf /etc/nginx/conf.d/ssl.conf
+COPY ssl.conf /etc/nginx/external/ssl.conf
 
 WORKDIR /var/www/html
 VOLUME /var/www/html
@@ -110,4 +110,5 @@ VOLUME /var/www/html
 EXPOSE 80 443
 
 COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod 755 /usr/local/bin/docker-entrypoint.sh
 CMD "docker-entrypoint.sh"

--- a/1.10/Dockerfile
+++ b/1.10/Dockerfile
@@ -31,7 +31,8 @@ RUN addgroup -S -g 82 www-data && \
         zlib-dev \
         geoip-dev\
         luajit \
-        luajit-dev && \
+        luajit-dev \
+        openssl && \
 
     # Download nginx and its modules source code
     wget -qO- http://nginx.org/download/nginx-${NGX_VER}.tar.gz | tar xz -C /tmp/ && \
@@ -91,7 +92,8 @@ RUN addgroup -S -g 82 www-data && \
     chmod -R 777 /var/lib/nginx/tmp && \
     mkdir -p /etc/nginx/pki && \
     chmod 400 /etc/nginx/pki && \
-
+    mkdir -p /etc/nginx/external && \
+    
     # Cleanup
     apk del *-dev build-base autoconf libtool && \
     rm -rf /var/cache/apk/* /tmp/*
@@ -100,6 +102,7 @@ RUN addgroup -S -g 82 www-data && \
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY fastcgi_params /etc/nginx/fastcgi_params
 COPY drupal* /opt/
+ADD ssl.conf /etc/nginx/conf.d/ssl.conf
 
 WORKDIR /var/www/html
 VOLUME /var/www/html

--- a/1.10/docker-entrypoint.sh
+++ b/1.10/docker-entrypoint.sh
@@ -36,4 +36,32 @@ if [ -n "$NGINX_SERVER_NAME" ]; then
     sed -i 's/SERVER_NAME/'"${NGINX_SERVER_NAME}"'/' /etc/nginx/conf.d/*.conf
 fi
 
+# Enable Self Signed Cert
+DH_SIZE="2048"
+
+DH="/etc/nginx/external/dh.pem"
+
+if [ ! -e "$DH" ]
+then
+  echo ">> seems like the first start of nginx"
+  echo ">> doing some preparations..."
+  echo ""
+
+  echo ">> generating $DH with size: $DH_SIZE"
+  openssl dhparam -out "$DH" $DH_SIZE
+fi
+
+if [ ! -e "/etc/nginx/external/cert.pem" ] || [ ! -e "/etc/nginx/external/key.pem" ]
+then
+  echo ">> generating self signed cert"
+  openssl req -x509 -newkey rsa:4086 \
+  -subj "/C=XX/ST=XXXX/L=XXXX/O=XXXX/CN=localhost" \
+  -keyout "/etc/nginx/external/key.pem" \
+  -out "/etc/nginx/external/cert.pem" \
+  -days 3650 -nodes -sha256
+fi
+
+echo ">> copy /etc/nginx/external/*.conf files to /etc/nginx/conf.d/"
+cp /etc/nginx/external/*.conf /etc/nginx/conf.d/ 2> /dev/null > /dev/null
+
 exec nginx -g "daemon off;"

--- a/1.10/docker-entrypoint.sh
+++ b/1.10/docker-entrypoint.sh
@@ -36,7 +36,7 @@ fi
 if [ -n "$NGINX_SERVER_NAME" ]; then
     sed -i 's/SERVER_NAME/'"${NGINX_SERVER_NAME}"'/' /etc/nginx/conf.d/*.conf
 fi
-
+if
 # Enable Self Signed Cert
 DH_SIZE="2048"
 

--- a/1.10/docker-entrypoint.sh
+++ b/1.10/docker-entrypoint.sh
@@ -18,6 +18,7 @@ fi
 
 # Copy default nginx config.
 if [[ ! "$(ls -A /etc/nginx/conf.d)" ]]; then
+	echo " --  copying drupal nginx configs"
     cp /opt/drupal${DRUPAL_VERSION}.conf /etc/nginx/conf.d/
 fi
 
@@ -43,25 +44,31 @@ DH="/etc/nginx/external/dh.pem"
 
 if [ ! -e "$DH" ]
 then
-  echo ">> seems like the first start of nginx"
-  echo ">> doing some preparations..."
+  echo " --  seems like the first start of nginx so generating certs for SSL"
   echo ""
-
-  echo ">> generating $DH with size: $DH_SIZE"
-  openssl dhparam -out "$DH" $DH_SIZE
+  cp /etc/nginx/external/ssl.conf /etc/nginx/conf.d
+  echo " --  generating $DH with size: $DH_SIZE"
+  openssl dhparam -out "$DH" $DH_SIZE 
 fi
 
 if [ ! -e "/etc/nginx/external/cert.pem" ] || [ ! -e "/etc/nginx/external/key.pem" ]
 then
-  echo ">> generating self signed cert"
+  echo " --  generating self signed cert"
   openssl req -x509 -newkey rsa:4086 \
   -subj "/C=XX/ST=XXXX/L=XXXX/O=XXXX/CN=localhost" \
   -keyout "/etc/nginx/external/key.pem" \
   -out "/etc/nginx/external/cert.pem" \
-  -days 3650 -nodes -sha256
+  -days 3650 -nodes -sha256 && \
+  cp /etc/nginx/external/*.conf /etc/nginx/conf.d/ 2> /dev/null > /dev/null && \
+  echo " --  starting nginx"
+  exec nginx -g "daemon off;"
+else
+  echo " --  only copy /etc/nginx/external/*.conf files to /etc/nginx/conf.d/"
+  cp /etc/nginx/external/*.conf /etc/nginx/conf.d/ 2> /dev/null > /dev/null && \
+  echo " --  starting nginx"
+  exec nginx -g "daemon off;"
 fi
 
-echo ">> copy /etc/nginx/external/*.conf files to /etc/nginx/conf.d/"
-cp /etc/nginx/external/*.conf /etc/nginx/conf.d/ 2> /dev/null > /dev/null
 
-exec nginx -g "daemon off;"
+
+

--- a/1.10/drupal8.conf
+++ b/1.10/drupal8.conf
@@ -2,6 +2,12 @@ server {
     server_name SERVER_NAME;
     listen 80;
 
+    listen 443 ssl;
+
+    ssl_certificate /etc/nginx/external/cert.pem;
+    ssl_certificate_key /etc/nginx/external/key.pem;
+
+
     root /var/www/html/;
     index index.php;
 

--- a/1.10/ssl.conf
+++ b/1.10/ssl.conf
@@ -1,0 +1,15 @@
+# Getting a high secure SSL configured system
+
+# Tutorials used:
+# https://scotthelme.co.uk/a-plus-rating-qualys-ssl-test/
+# http://www.howtoforge.com/ssl-perfect-forward-secrecy-in-nginx-webserver
+
+# enable dh
+ssl_dhparam /etc/nginx/external/dh.pem;
+
+# protocols
+ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # disable poodle
+
+# ciphers
+ssl_prefer_server_ciphers on;
+ssl_ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS;


### PR DESCRIPTION
See: [https://github.com/wodby/drupal-nginx/issues/15](https://github.com/wodby/drupal-nginx/issues/15) :: building the docker container performs the creation and registration of a self signed certificate within NGINX.  Port 443 is available via a web browser.   Browser needs to allow the use of the site as the ssl connection is suspect.  